### PR TITLE
feat: update node version to 14 as onesignal now depends on it

### DIFF
--- a/2.4.1-stretch-node-14/Dockerfile
+++ b/2.4.1-stretch-node-14/Dockerfile
@@ -1,0 +1,34 @@
+FROM ruby:2.4.1-stretch
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV ONESIGNAL_CAPNPROTO_RELEASE_URL="https://github.com/OneSignal/capnproto-debian/releases/download/onesignal-0.6.1-1" \
+    ONESIGNAL_CAPNPROTO_DEB="capnproto_0.6.1-1_amd64.deb" \
+    ONESIGNAL_LIBCAPNP_DEB="libcapnp-0.6.1_0.6.1-1_amd64.deb" \
+    ONESIGNAL_LIBCAPNP_DEV_DEB="libcapnp-dev_0.6.1-1_amd64.deb"
+ENV LIBSSL_RELEASE_URL="http://archive.debian.org/debian/pool/main/o/openssl" \
+    LIBSSL_DEB="libssl1.0.0_1.0.2l-1~bpo8+1_amd64.deb" \
+    LIBSSL_DEV_DEB="libssl-dev_1.0.2l-1~bpo8+1_amd64.deb"
+
+RUN set -ex \
+    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+    && echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' >> /etc/apt/sources.list.d/pgdg.list \
+    && echo "deb http://ftp.debian.org/debian stretch-backports main" >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y \
+        git curl lftp zsh vim zip postgresql-10 postgresql-client-10 netcat \
+    && cd /tmp \
+    && curl -sSLO "${LIBSSL_RELEASE_URL}/${LIBSSL_DEB}" \
+    && curl -sSLO "${LIBSSL_RELEASE_URL}/${LIBSSL_DEV_DEB}" \
+    && curl -sSLO "${ONESIGNAL_CAPNPROTO_RELEASE_URL}/${ONESIGNAL_CAPNPROTO_DEB}" \
+    && curl -sSLO "${ONESIGNAL_CAPNPROTO_RELEASE_URL}/${ONESIGNAL_LIBCAPNP_DEB}" \
+    && curl -sSLO "${ONESIGNAL_CAPNPROTO_RELEASE_URL}/${ONESIGNAL_LIBCAPNP_DEV_DEB}" \
+    && dpkg -i "${ONESIGNAL_CAPNPROTO_DEB}" "${ONESIGNAL_LIBCAPNP_DEB}" "${ONESIGNAL_LIBCAPNP_DEV_DEB}" "${LIBSSL_DEB}" "${LIBSSL_DEV_DEB}" \
+    && gem install bundler -v 2.2.16 \
+    && wget -qO- https://deb.nodesource.com/setup_14.x | bash - \
+    && apt-get install -y nodejs \
+    && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg |  apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" |  tee /etc/apt/sources.list.d/yarn.list \
+    && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update && apt-get install yarn \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Onesignal application now depends on node 14 to be able to compile assets.

![image](https://user-images.githubusercontent.com/83188/115202253-847b3c80-a0f6-11eb-8e3d-2b67259b37e1.png)

This PR adds a new image for that based on the 10 one, in the end is just a `cp` and a :

```
-  && wget -qO- https://deb.nodesource.com/setup_10.x | bash - \ 
-----
+ && wget -qO- https://deb.nodesource.com/setup_14.x | bash - \
```

**The new image is already pushed to our docker hub account, as a *side effect*, the `deploy.sh` script also recreated the other images, I thought it would be safe, so I let it do it**
